### PR TITLE
Addt'l changes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,100 +3,46 @@
 @import "tailwindcss/utilities";
 
 /* This file is for your main application CSS */
+
+/* Main color palette + white/black */
+.color1 {color: #e9d8ff;}
+.color2 {color: #fffbff;}
+.color3 {color: #1d1832;}
+.color4 {color: #78767c;}
+.color5 {color: #e2e2e2;}
   
-  .color1 {color: #e9d8ff;}
-  .color2 {color: #fffbff;}
-  .color3 {color: #1d1832;}
-  .color4 {color: #78767c;}
-  .color5 {color: #e2e2e2;}
+.header {
+  min-height: 100px;
+  background-color: #1d1832;
+  color: white;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
   
-  img {
-    width: 50px;
-  }
+.logo {
+  max-width: 150px;
+  margin-left: 2.5rem;
+}
   
-  .header {
-    min-height: 100px;
-    background-color: #1d1832;
-    color: white;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
+.main-menu {
+  width: 300px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+}
   
-  .logo {
-    max-width: 150px;
-    margin-left: 2.5rem;
-  }
-  
-  .main-menu {
-    width: 300px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-  }
-  
-  .reader-menu {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
-  
-  /* The side navigation menu */
-  .sidenav {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    width: 0; /* changes with script */
-    height: 70px;
-    margin-top: -9px;
-    position: fixed; /* Stay in place */
-    z-index: 1; /* Stay on top */
-    background-color: #1d1832; /* Black*/
-    color:white;
-    overflow-x: hidden; /* Disable horizontal scroll */
-    transition: 0.5s; /* 0.5 second transition effect to slide in the sidenav */
-  }
-  
-  .sidenav a {
-    padding: 8px 8px 8px 32px;
-    text-decoration: none;
-    font-size: 25px;
-    color: #818181;
-    display: block;
-    transition: 0.3s;
-  }
-  
-  .sidenav img {
-    padding: 8px 8px 8px 32px;
-    text-decoration: none;
-    font-size: 25px;
-    color: #818181;
-    display: block;
-    transition: 0.3s;
-  }
-  
-  .sidenav a:hover {
-    color: #f1f1f1;
-  }
-  
-  /* Position and style the close button (top right corner) */
-  .sidenav .closebtn {
-    position: absolute;
-    right: 18px;
-    font-size: 28px;
-    margin-left: 50px;
-  }
-  
-  /* Style page content - use this if you want to push the page content to the right when you open the side navigation */
-  #main {
-    transition: margin-left .5s;
-    padding: 20px;
-  }
-  
-  /* On smaller screens, where height is less than 450px, change the style of the sidenav (less padding and a smaller font size) */
-  @media screen and (max-height: 450px) {
-    .sidenav {padding-top: 15px;}
-    .sidenav a {font-size: 18px;}
-  }  
+.reader-menu {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.controls-button {
+  background-color: #1d1832;
+  color:white;
+  border-radius: 9999px;
+  min-width: 150px;
+  min-height: 50px;
+}

--- a/lib/reader_web/live/reader_live/index.html.heex
+++ b/lib/reader_web/live/reader_live/index.html.heex
@@ -10,57 +10,41 @@
   </section>
 </header>
 
-<%!-- Side Nav --%>
-<section>
-        <div id="mySidenav" class="sidenav">
-            <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
-            <span class="material-symbols-rounded">space_bar</span>Start/Stop
-            <span class="material-symbols-rounded">arrow_upward_alt</span>Speed Up
-            <span class="material-symbols-rounded">arrow_downward_alt</span>Slow Down
-            <span class="material-symbols-rounded">arrow_left_alt</span>Rewind
-            <span class="material-symbols-rounded">arrow_right_alt</span>Forward
-            <span></span>ESC Exit
-        </div>
-        <section class="reader-menu my-[10px] ml-[2.5rem]">
-            <h1><span onclick="openNav()">Instructions |</span>
-            <span>Upload |</span>
-            <span>Another Menu Item |</span></h1>
-        </section>
-    </section>
+<%!-- Sub Menu --%>
+<section class="reader-menu my-[10px] ml-[2.5rem]">
+  <h1><span onclick="openNav()">Instructions |</span>
+  <span>Upload |</span>
+  <span>Another Menu Item |</span></h1>
+</section>
 
-<div class="m-10" phx-window-keydown="press">
-  <h1>Reader!</h1>
-
-  <!-- Words pane -->
-  <div class="h-40 m-10 justify-center">
-    <div class="text-gray-300 text-sm"><%= @last %></div>
-    <div class="text-black text-xl"><%= @current %></div>
-    <div class="text-gray-300 text-sm"><%= @next %></div>
-  </div>
-
-  <!-- Controls -->
-  <div class="h-10 m-10">
-    <div>
-      <button phx-click="next" class="btn btn-blue">Next</button>
+<%!-- Reader Area --%>
+<section class="mx-80">
+<!-- Reader Pane -->
+  <section class="flex flex-row justify-center h-64 mt-12 mb-4 border-8 border-[#1d1832] rounded-[2.5rem] bg-[steelblue]">
+    <div class="flex flex-col justify-center mx-80">
+      <div class="text-gray-300 text-4sm"><%= @last %></div>
+      <div class="text-black text-5xl"><%= @current %></div>
+      <div class="text-gray-300 text-4sm"><%= @next %></div>
     </div>
-  </div>
+  </section>
 
-  <!-- Settings -->
-  <div class="h-10 m-10">
+<!-- Info Area -->
+  <section class="flex flex-row justify-center mb-4">
     <div>
-      <p><b>Paused</b>: <%= not @auto %></p>
-      <p><b>WPM</b>: <%= @wpm %></p>
+      <b>Paused</b>: <%= not @auto %>
+      <b>WPM</b>: <%= @wpm %>
     </div>
-  </div>
-</div>
+  </section>
 
-<%!-- Side NAV script --%>
-<script>/* Set the width of the side navigation to max avilable */
-    function openNav() {
-      document.getElementById("mySidenav").style.width = "100%";
-    }
-    
-    /* Set the width of the side navigation to 0 */
-    function closeNav() {
-      document.getElementById("mySidenav").style.width = "0";
-    }</script>
+<!-- Controls -->
+  <section class="flex flex-row justify-evenly">
+    <button class="controls-button" phx-click="next"><i class="material-symbols-rounded">space_bar</i>Start/Stop</button>
+    <button class="controls-button" phx-click="next"><i class="material-symbols-rounded">arrow_upward_alt</i>Speed Up</button>
+    <button class="controls-button" phx-click="next"><i class="material-symbols-rounded">arrow_downward_alt</i>Slow Down</button>
+    <button class="controls-button" phx-click="next"><i class="material-symbols-rounded">arrow_left_alt</i>Rewind</button>
+    <button class="controls-button" phx-click="next"><i class="material-symbols-rounded">arrow_right_alt</i>Forward</button>
+  </section>
+</section>
+
+<%!-- Bindings --%>
+<div class="m-10" phx-window-keydown="press"></div>


### PR DESCRIPTION
Removed slider-bar

Setup Reader Area - in three sections, as follows:
Reader Pane: display words - larger font used, added background, and borders
Info Area: displays WPM and Pause state
Controls: added buttons w/icons  to all controls actions - removed ESC as it is not used.
Moved bindings section to bottom of page

About functionality: Only "next" has the correct functionality. I noticed others, like backwards, and last - however, these do not function as next - they seem to be browser actions for "back".